### PR TITLE
ShlomiShitrit/issue25 - add more then one parameter query

### DIFF
--- a/BotUI/src/app/api/root/route.ts
+++ b/BotUI/src/app/api/root/route.ts
@@ -1,32 +1,50 @@
-import { QueryReq } from "@/app/general/interfaces";
+import { Attribute } from "@/app/general/interfaces";
 import { getOperator } from "@/app/general/utils";
+import { strOrNum } from "@/app/general/types";
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import csvParser from "csv-parser";
 
 export async function POST(request: NextRequest) {
     const req = await request.json();
-    const queryReq = req.queryReq as QueryReq[];
+    const attributes = req.queryParams as Attribute[];
     const filePath = req.filePath as string;
-    const rows = await filterCSV(filePath, queryReq);
+    const rows = await filterCSV(filePath, attributes);
     return NextResponse.json(rows);
 }
 
-export async function filterCSV(filePath: string, queryReq: QueryReq[]) {
+async function filterCSV(filePath: string, attributes: Attribute[]) {
     return new Promise<any[]>((resolve, reject) => {
-        const operators = queryReq.map(
+        const operators = attributes.map(
             (query) => getOperator(query.operator) as any
         );
         const rows: any[] = [];
         fs.createReadStream(filePath)
             .pipe(csvParser())
             .on("data", (row: any) => {
-                const isRequired = queryReq.every((query, index) =>
-                    operators[index](
-                        row[query.parameter],
-                        ...query.functionParams
-                    )
-                );
+                let isRequired: boolean = true;
+                const duplicates = findDuplicates(attributes, "name");
+                if (duplicates.length > 0) {
+                    const notDuplicatesAttributes = attributes.filter(
+                        (attribute) => !duplicates.includes(attribute)
+                    );
+                    const isRequiredNotDuplicates =
+                        notDuplicatesAttributes.every((query, index) =>
+                            operators[index](row[query.name], ...query.params)
+                        );
+
+                    const isRequiredDuplicates = duplicates.some(
+                        (query, index) =>
+                            operators[index](row[query.name], ...query.params)
+                    );
+                    isRequired =
+                        isRequiredNotDuplicates && isRequiredDuplicates;
+                } else {
+                    isRequired = attributes.every((query, index) =>
+                        operators[index](row[query.name], ...query.params)
+                    );
+                }
+
                 if (isRequired) {
                     rows.push(row);
                 }
@@ -38,4 +56,15 @@ export async function filterCSV(filePath: string, queryReq: QueryReq[]) {
                 reject(error);
             });
     });
+}
+
+function findDuplicates(arr: Attribute[], key: keyof Attribute): Attribute[] {
+    const occurrences = new Map<strOrNum[] | string, number>();
+
+    arr.forEach((obj) => {
+        const value = obj[key];
+        occurrences.set(value, (occurrences.get(value) || 0) + 1);
+    });
+
+    return arr.filter((obj) => occurrences.get(obj[key])! > 1);
 }

--- a/BotUI/src/app/api/root/route.ts
+++ b/BotUI/src/app/api/root/route.ts
@@ -22,9 +22,7 @@ async function filterCSV(filePath: string, attributes: Attribute[]) {
         fs.createReadStream(filePath)
             .pipe(csvParser())
             .on("data", (row: any) => {
-                const isRequired = isRowRequired(attributes, operators, row);
-
-                if (isRequired) {
+                if (isRowRequired(attributes, operators, row)) {
                     rows.push(row);
                 }
             })

--- a/BotUI/src/app/components/Chat/Chat.tsx
+++ b/BotUI/src/app/components/Chat/Chat.tsx
@@ -13,7 +13,7 @@ import {
     isResultsAtom,
     isQuerySubmitAtom,
 } from "@/app/store/atoms";
-import { ChatProps, QueryReq } from "@/app/general/interfaces";
+import { ChatProps } from "@/app/general/interfaces";
 import { resultMsg } from "@/app/general/resources";
 import CSVButton from "@/app/components/CSVButton";
 
@@ -24,7 +24,7 @@ export default function Chat({ bot }: ChatProps) {
     const [queryWords, setQueryWords] = useRecoilState(queryWordsAtom);
     const [isResult, setIsResult] = useRecoilState(isResultsAtom);
     const [isQuerySubmit, ___] = useRecoilState(isQuerySubmitAtom);
-    const [loading, setloading] = useState<boolean>(false);
+    const [loading, setLoading] = useState<boolean>(false);
 
     const messagesEndRef = useRef(null);
 
@@ -39,20 +39,7 @@ export default function Chat({ bot }: ChatProps) {
     useEffect(() => {
         const getQueryWords = async () => {
             try {
-                setloading(true);
-                const queryReq: QueryReq[] = [];
-                Object.entries(queryParams).forEach((entry) => {
-                    const [parameter, attribute] = entry;
-                    if (attribute !== null) {
-                        const { value, operator, params } = attribute;
-                        queryReq.push({
-                            parameter,
-                            operator,
-                            value,
-                            functionParams: params,
-                        });
-                    }
-                });
+                setLoading(true);
 
                 const pathArray = bot?.filePath.split("/");
                 const lastPathItem = pathArray.pop();
@@ -61,7 +48,7 @@ export default function Chat({ bot }: ChatProps) {
                 const response = await fetch("/api/root", {
                     method: "POST",
                     body: JSON.stringify({
-                        queryReq,
+                        queryParams,
                         filePath: path,
                     }),
                 });
@@ -74,7 +61,7 @@ export default function Chat({ bot }: ChatProps) {
             } catch (err: any) {
                 console.log(err.message);
             } finally {
-                setloading(false);
+                setLoading(false);
             }
         };
         if (isQuerySubmit) {

--- a/BotUI/src/app/components/ChatBox/ChatBox.tsx
+++ b/BotUI/src/app/components/ChatBox/ChatBox.tsx
@@ -17,6 +17,7 @@ export default function ChatBox({ bot }: ChatBoxProps) {
     const [_, setIsQuerySubmit] = useRecoilState(isQuerySubmitAtom);
     const [__, setQueryParams] = useRecoilState(queryParamsAtom);
     const [isStringParameter, setIsStringParameter] = useState<boolean>(false);
+    const [isEndSection, setIsEndSection] = useState<boolean>(false);
     const [lastQuestionIndex, setLastQuestionIndex] = useState<number>(
         botMessages.length - 1
     );
@@ -25,6 +26,7 @@ export default function ChatBox({ bot }: ChatBoxProps) {
         state: isStringParameter,
         setState: setIsStringParameter,
     };
+    const endSection = { state: isEndSection, setState: setIsEndSection };
 
     const { currentMsg, currentQIndex, endChat } = useChat();
     const { handleUserInput, botMsg, isSubmit } = useInput(
@@ -32,16 +34,18 @@ export default function ChatBox({ bot }: ChatBoxProps) {
         currentQIndex,
         lastQuestionIndex,
         bot,
-        strParam
+        strParam,
+        setIsEndSection
     );
 
-    const { endSection, updateMessagesSection } = useUpdateMsg(
+    const { updateMessagesSection } = useUpdateMsg(
         currentMsg,
         botMsg,
-        currentQIndex.state
+        currentQIndex.state,
+        endSection
     );
 
-    const { handleEndChat } = useEndChat(strParam, bot);
+    const { handleEndChat } = useEndChat(bot);
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -66,8 +70,8 @@ export default function ChatBox({ bot }: ChatBoxProps) {
 
     useEffect(() => {
         if (endChat.state) {
-            const params = handleEndChat();
-            setQueryParams(params);
+            const queryAttributes = handleEndChat();
+            setQueryParams(queryAttributes);
             setIsQuerySubmit(true);
         }
     }, [endChat.state]);

--- a/BotUI/src/app/components/ChatBox/ChatBox.tsx
+++ b/BotUI/src/app/components/ChatBox/ChatBox.tsx
@@ -70,8 +70,7 @@ export default function ChatBox({ bot }: ChatBoxProps) {
 
     useEffect(() => {
         if (endChat.state) {
-            const queryAttributes = handleEndChat();
-            setQueryParams(queryAttributes);
+            setQueryParams(handleEndChat());
             setIsQuerySubmit(true);
         }
     }, [endChat.state]);

--- a/BotUI/src/app/general/interfaces.ts
+++ b/BotUI/src/app/general/interfaces.ts
@@ -84,27 +84,14 @@ export enum DataType {
     String = "string",
 }
 
-export interface QueryReq {
-    value: strOrNum | number[];
-    operator: string;
-    functionParams: strOrNum[];
-    parameter: string;
-}
-
-export interface NumericAttribute {
-    value: number | number[];
-    params: strOrNum[];
-    operator: string;
-}
-
-export interface StringAttribute {
-    value: string;
+export interface Attribute {
+    name: string;
     params: strOrNum[];
     operator: string;
 }
 
 export interface QueryWords {
-    [key: string]: NumericAttribute | StringAttribute | null;
+    [key: string]: Attribute;
 }
 
 export interface WordData {

--- a/BotUI/src/app/hooks/useInput.ts
+++ b/BotUI/src/app/hooks/useInput.ts
@@ -23,11 +23,11 @@ export default function useInput(
     strParam: {
         state: boolean;
         setState: Dispatch<SetStateAction<boolean>>;
-    }
+    },
+    setIsEndSection: Dispatch<SetStateAction<boolean>>
 ) {
     const [botMsg, setBotMsg] = useState<Message[]>(botMessages(bot));
     const [isSubmit, setIsSubmit] = useState<boolean>(false);
-    const [_, setIsEndSection] = useState<boolean>(false);
 
     const handleUserInput = (
         input: string,

--- a/BotUI/src/app/hooks/useUpdateMsg.ts
+++ b/BotUI/src/app/hooks/useUpdateMsg.ts
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { currentMsgType } from "@/app/general/types";
 import { Message, MessageSection } from "@/app/general/interfaces";
 import { useRecoilState } from "recoil";
@@ -7,10 +6,13 @@ import { messagesSectionAtom } from "@/app/store/atoms";
 export default function useUpdateMsg(
     currentMsg: currentMsgType,
     botMsg: Message[],
-    currentQuestionIndex: number
+    currentQuestionIndex: number,
+    endSection: {
+        state: boolean;
+        setState: (value: boolean) => void;
+    }
 ) {
     const [messages, setMessages] = useRecoilState(messagesSectionAtom);
-    const [isEndSection, setIsEndSection] = useState<boolean>(false);
 
     const updateMessagesSection = (isEndChat: boolean) => {
         const lastMessageIndex = messages.length - 1;
@@ -25,20 +27,18 @@ export default function useUpdateMsg(
                 id: prevMessages.length,
                 messageSection: [...currentMsg.state],
             };
-            return isEndSection
+            return endSection.state
                 ? [...updatedMessages, newMessageSection]
                 : updatedMessages;
         });
-        if (isEndSection) {
+        if (endSection.state) {
             currentMsg.setState(
                 !isEndChat ? [botMsg[currentQuestionIndex]] : []
             );
         }
 
-        setIsEndSection(false);
+        endSection.setState(false);
     };
-
-    const endSection = { state: isEndSection, setState: setIsEndSection };
 
     return { endSection, updateMessagesSection };
 }

--- a/BotUI/src/app/operators/operators.ts
+++ b/BotUI/src/app/operators/operators.ts
@@ -1,3 +1,4 @@
+
 import {
     greaterOperator,
     lowerOperator,
@@ -15,3 +16,6 @@ export const OPERATORS = {
     SoundLike: soundLikeOperator,
     StartWith: startWithOperator,
 };
+
+
+

--- a/BotUI/src/app/store/atoms.ts
+++ b/BotUI/src/app/store/atoms.ts
@@ -4,6 +4,7 @@ import {
     Message,
     QueryWords,
     Bot,
+    Attribute,
 } from "@/app/general/interfaces";
 import { defaultMsgSection } from "@/app/general/resources";
 
@@ -12,9 +13,9 @@ export const messagesSectionAtom: RecoilState<MessageSection[]> = atom({
     default: defaultMsgSection,
 });
 
-export const queryParamsAtom: RecoilState<QueryWords> = atom({
+export const queryParamsAtom: RecoilState<Attribute[]> = atom({
     key: "queryParams",
-    default: {} as QueryWords,
+    default: [] as Attribute[],
 });
 
 export const queryWordsAtom: RecoilState<any> = atom({

--- a/BotUI/tsconfig.json
+++ b/BotUI/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Fixes #25

Now the query can handle multiple parameters.

For example:
if the attribute "name"  has been with the operator "startWith" twice - for "a" and for "b"
and the attribute "gender" has been chosen with the operator "startWith" twice - for "m"  and for "f":

The results are:

![image](https://github.com/GoldenLabHuji/DBbot/assets/110962795/c8f41b8d-c304-4ae7-b99f-5807ba768f6b)
from  sw_characters csv file
