### PR TITLE
ShlomiShitrit/issue29 - null values

### DIFF
--- a/DBbot/classes/DBbot.ts
+++ b/DBbot/classes/DBbot.ts
@@ -11,7 +11,10 @@ import {
     BotData,
     BotMessages,
     CustomMessages,
+    nullMethod,
     MessagesSlot,
+    NumOrStr,
+    fillNullValuesParams,
 } from "../general/types";
 import {
     OPERATOR_PATHS,
@@ -100,7 +103,7 @@ You can download the results as a csv file`,
         this.setMessages("slots", messages);
     }
 
-    private getColumnByName(name: string) {
+    public getColumnByName(name: string) {
         const column = this._data.columns.find(
             (column) => column.id.toLowerCase() === name.toLowerCase()
         );
@@ -231,13 +234,26 @@ export const ${params.name} = ${params.customFunction.toString()};`
         });
     }
 
+    public fillNullValuesAll({
+        numericValue,
+        stringValue,
+        nullValue = [null],
+    }: fillNullValuesParams): void {
+        this._data.columns.forEach((column) => {
+            const value =
+                column.dataType === "numeric" ? numericValue : stringValue;
+            if (value === undefined) return;
+            column.fillNullValues("custom", nullValue, value);
+        });
+    }
+
     private addColumnsAuto(): void {
         this._data.headers.forEach((column) => {
             const columnData = this.dataMap.get(column);
             if (columnData && columnData.length > 0) {
-                const isNumeric = columnData.every((item: string) => {
-                    return !isNaN(Number(item));
-                });
+                const isNumeric = columnData.some(
+                    (item: string) => !isNaN(Number(item))
+                );
                 const dataType: DataType = isNumeric ? "numeric" : "string";
                 const col = new Column(column, dataType);
                 const numberColumnData: number[] = columnData.map(

--- a/DBbot/classes/column.ts
+++ b/DBbot/classes/column.ts
@@ -7,14 +7,14 @@ import {
     SoundLikeOperator,
     StartsWithOperator,
 } from "./operator";
-import { DataType, ColumnData } from "../general/types";
+import { DataType, ColumnData, nullMethod, NumOrStr } from "../general/types";
 
 export class Column {
     private rows: any[] = [];
     private operatorsArray: Operator[] = [];
     constructor(
         public readonly id: string,
-        private dataType: DataType,
+        public dataType: DataType,
         private displayName: string = id,
         private customOperators: Operator[] = []
     ) {
@@ -57,5 +57,88 @@ export class Column {
 
     public addOperator(operator: Operator): void {
         this.operatorsArray.push(operator);
+    }
+
+    public mean(): number {
+        if (this.dataType === "string") {
+            throw new Error("Cannot calculate mean for string data type");
+        }
+        const sum = this.rows.reduce((acc, curr) => {
+            if (isNaN(curr)) return acc + 0;
+            return acc + curr;
+        }, 0);
+        const mean = sum / this.rows.length;
+        return Math.round(mean * 100) / 100;
+    }
+
+    public mode(): number {
+        if (this.dataType === "string") {
+            throw new Error("Cannot calculate mode for string data type");
+        }
+        const counts = this.rows.reduce((acc, curr) => {
+            if (isNaN(curr)) return acc;
+            if (!acc[curr]) {
+                acc[curr] = 1;
+            } else {
+                acc[curr]++;
+            }
+            return acc;
+        }, {});
+        const max = Math.max(...(Object.values(counts) as number[]));
+        const result =
+            Number(Object.keys(counts).find((key) => counts[key] === max)) ??
+            -1;
+        if (result === -1) {
+            throw new Error("No mode found");
+        }
+        return result;
+    }
+
+    public median(): number {
+        if (this.dataType === "string") {
+            throw new Error("Cannot calculate median for string data type");
+        }
+        const notNaNRows = this.rows.filter((row) => !isNaN(row));
+        const sortedRows = notNaNRows.sort((a, b) => {
+            return a - b;
+        });
+        const mid = Math.floor(sortedRows.length / 2);
+        if (sortedRows.length % 2 === 0) {
+            return (sortedRows[mid - 1] + sortedRows[mid]) / 2;
+        }
+        return sortedRows[mid];
+    }
+
+    private fillRow(inputValue: NumOrStr, nullValue: any[] = [null]): void {
+        this.rows.forEach((row, index) => {
+            if (nullValue.includes(row)) {
+                this.rows[index] = inputValue;
+            }
+        });
+    }
+
+    public fillNullValues(
+        method: nullMethod,
+        nullValue: any[] = [null],
+        customValue?: NumOrStr
+    ): void {
+        if (method === "custom") {
+            if (customValue === undefined) {
+                throw new Error("Custom value is required");
+            }
+            this.fillRow(customValue, nullValue);
+        } else if (method === "remove") {
+            this.rows = this.rows.filter((row) => row !== nullValue);
+        } else if (method === "mean") {
+            this.fillRow(this.mean(), nullValue);
+        } else if (method === "median") {
+            this.fillRow(this.median(), nullValue);
+        } else if (method === "mode") {
+            this.fillRow(this.mode(), nullValue);
+        } else {
+            throw new Error(
+                "Invalid method, Please provide a valid method of the following 'mean', 'median', 'mode', 'remove' or 'custom'"
+            );
+        }
     }
 }

--- a/DBbot/classes/column.ts
+++ b/DBbot/classes/column.ts
@@ -79,14 +79,14 @@ export class Column {
         if (this.dataType === "string") {
             throw new Error("Cannot calculate mode for string data type");
         }
-        const counts = this.rows.reduce((acc, curr) => {
-            if (isNaN(curr)) return acc;
-            if (!acc[curr]) {
-                acc[curr] = 1;
+        const counts = this.rows.reduce((accuracy, current) => {
+            if (isNaN(current)) return accuracy;
+            if (!accuracy[current]) {
+                accuracy[current] = 1;
             } else {
-                acc[curr]++;
+                accuracy[current]++;
             }
-            return acc;
+            return accuracy;
         }, {});
         const max = Math.max(...(Object.values(counts) as number[]));
         const result =

--- a/DBbot/classes/column.ts
+++ b/DBbot/classes/column.ts
@@ -7,6 +7,13 @@ import {
     SoundLikeOperator,
     StartsWithOperator,
 } from "./operator";
+import {
+    DATATYPE_ERROR,
+    STRING_CALCULATION_ERROR,
+    MODE_ERROR,
+    CUSTOM_ERROR,
+    METHOD_ERROR,
+} from "../general/resources";
 import { DataType, ColumnData, nullMethod, NumOrStr } from "../general/types";
 
 export class Column {
@@ -37,7 +44,7 @@ export class Column {
                 ...[...stringOperators, ...this.customOperators]
             );
         } else {
-            throw new Error("Invalid data type");
+            throw new Error(DATATYPE_ERROR);
         }
     }
 
@@ -65,7 +72,7 @@ export class Column {
 
     public mean(): number {
         if (this.dataType === "string") {
-            throw new Error("Cannot calculate mean for string data type");
+            throw new Error(STRING_CALCULATION_ERROR);
         }
         const sum = this.rows.reduce((acc, curr) => {
             if (isNaN(curr)) return acc + 0;
@@ -77,7 +84,7 @@ export class Column {
 
     public mode(): number {
         if (this.dataType === "string") {
-            throw new Error("Cannot calculate mode for string data type");
+            throw new Error(STRING_CALCULATION_ERROR);
         }
         const counts = this.rows.reduce((accuracy, current) => {
             if (isNaN(current)) return accuracy;
@@ -93,14 +100,14 @@ export class Column {
             Number(Object.keys(counts).find((key) => counts[key] === max)) ??
             -1;
         if (result === -1) {
-            throw new Error("No mode found");
+            throw new Error(MODE_ERROR);
         }
         return result;
     }
 
     public median(): number {
         if (this.dataType === "string") {
-            throw new Error("Cannot calculate median for string data type");
+            throw new Error(STRING_CALCULATION_ERROR);
         }
         const notNaNRows = this.rows.filter((row) => !isNaN(row));
         const sortedRows = notNaNRows.sort((a, b) => {
@@ -128,7 +135,7 @@ export class Column {
     ): void {
         if (method === "custom") {
             if (customValue === undefined) {
-                throw new Error("Custom value is required");
+                throw new Error(CUSTOM_ERROR);
             }
             this.fillRow(customValue, nullValue);
         } else if (method === "remove") {
@@ -140,9 +147,7 @@ export class Column {
         } else if (method === "mode") {
             this.fillRow(this.mode(), nullValue);
         } else {
-            throw new Error(
-                "Invalid method, Please provide a valid method of the following 'mean', 'median', 'mode', 'remove' or 'custom'"
-            );
+            throw new Error(METHOD_ERROR);
         }
     }
 }

--- a/DBbot/general/resources.ts
+++ b/DBbot/general/resources.ts
@@ -4,8 +4,15 @@ import {
     CustomMessages,
     MessagesSlot,
     BotMessages,
-    OperatorsObject,
 } from "./types";
+
+export const DATATYPE_ERROR = "Invalid data type";
+export const STRING_CALCULATION_ERROR =
+    "Cannot calculate for string data type";
+export const MODE_ERROR = "No mode found";
+export const CUSTOM_ERROR = "Custom value is required";
+export const METHOD_ERROR =
+    "Invalid method, Please provide a valid method of the following 'mean', 'median', 'mode', 'remove' or 'custom'";
 
 export const OPERATOR_PATHS: Paths = {
     development: "../../BotUI/src/app/operators",

--- a/DBbot/general/types.ts
+++ b/DBbot/general/types.ts
@@ -5,6 +5,14 @@ export type DataType = "string" | "numeric";
 
 export type NumOrStr = number | string;
 
+export type nullMethod = "mean" | "median" | "mode" | "remove" | "custom";
+
+export type fillNullValuesParams = {
+    numericValue?: number;
+    stringValue?: string;
+    nullValue: any[];
+};
+
 export type Paths = {
     [key: string]: string;
 };

--- a/demo.csv
+++ b/demo.csv
@@ -2,3 +2,4 @@
 1,Bulbasaur,grass,80
 2,Squirtel,water,90
 3,Charmander,fire,100
+4,Eevee,,

--- a/scripts/demo.ts
+++ b/scripts/demo.ts
@@ -62,7 +62,23 @@ dbBot.slots = slots;
 // load csv file //
 ///////////////////
 
-dbBot.loadFile("./pokemon.csv");
+dbBot.loadFile("./sw_characters.csv");
+
+/////////////////////////
+// null values in rows //
+/////////////////////////
+
+const nullValues = [null, "NA", NaN];
+
+const heightColumn = dbBot.getColumnByName("height");
+
+heightColumn.fillNullValues("mean", nullValues);
+
+dbBot.fillNullValuesAll({
+    numericValue: -1,
+    stringValue: "FILL",
+    nullValue: nullValues,
+});
 
 /////////////////////
 // custom operator //


### PR DESCRIPTION
This pull request adds a new feature to fill null values in rows. It includes changes to the `Column` class, `DataType` type, and `fillNullValuesParams` type. The `Column` class now has a `fillNullValues` method that accepts different methods such as "mean", "median", "mode", "remove", or "custom" to fill null values with appropriate values. The `fillNullValues` method can be used on individual columns or on all columns at once using the `fillNullValuesAll` method. This feature enhances data cleaning and preprocessing capabilities.

**Example of use case:**

First the developer needs to define what is considered as null values. This is the values that will get filled:


![image](https://github.com/GoldenLabHuji/DBbot/assets/110962795/ed158ee8-0b62-42f2-ac40-ecf4c2fc891c)

Then the developer can either change a specific column:


![image](https://github.com/GoldenLabHuji/DBbot/assets/110962795/eddbadbc-698c-4b29-b95a-2497d88f7539)

Or the entire csv:


![image](https://github.com/GoldenLabHuji/DBbot/assets/110962795/3adfb2f0-bec4-44b2-b97e-a80d9b559105)


